### PR TITLE
Use a hidden canvas in memory to paint to avoid jank

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -5,3 +5,16 @@
 ```shell
 yarn && yarn dev
 ```
+
+> running for the first time
+
+```
+yarn build:midi
+```
+
+### firefox supported 52+
+
+add these extensions to enable WebMIDI
+
+- https://addons.mozilla.org/en-US/firefox/addon/jazz-midi/
+- https://addons.mozilla.org/en-US/firefox/addon/web-midi-api/

--- a/components/Piano/piano.css
+++ b/components/Piano/piano.css
@@ -1,6 +1,6 @@
 .keys {
   @apply flex select-none;
-  transition: all 200ms;
+  /* transition: all 200ms; */
 }
 
 .natural-keys {

--- a/components/SoundPlayer.tsx
+++ b/components/SoundPlayer.tsx
@@ -47,11 +47,12 @@ const SoundPlayer: React.FunctionComponent<{
   const [midiDevice, setSelectedMidiDevice] = useState(null);
   const [activeInstrumentMidis, setActiveInstrumentMidis] = useState([]);
 
-  const canvasProxyRef = useRef<any>(
-    offScreenCanvasSupport === OFFSCREEN_2D_CANVAS_SUPPORT.SUPPORTED
-      ? wrap(new CanvasWorker())
-      : controlVisualizer
-  );
+  // TODO: undo the ternary; not wrapping via Comlink to test offcanvas perf
+  // on latest chrome, too lazy to install anything else
+  const canvasProxyRef = useRef<any>(controlVisualizer);
+  // offScreenCanvasSupport === OFFSCREEN_2D_CANVAS_SUPPORT.SUPPORTED
+  //   ? controlVisualizer || wrap(new CanvasWorker())
+  //   : controlVisualizer
 
   useEffect(() => {
     player.set2dOffscreenCanvasSupport(offScreenCanvasSupport);

--- a/components/Visualizer/Visualizer.tsx
+++ b/components/Visualizer/Visualizer.tsx
@@ -24,6 +24,7 @@ const _Visualizer: FunctionComponent<VisualizerProps> = ({
   offScreenCanvasSupport
 }) => {
   const canvasRef = useRef<HTMLCanvasElement>(null);
+  let timeout = useRef<NodeJS.Timer>(undefined as any).current;
   const hiddenCanvasElement = useRef<HTMLCanvasElement>(
     document.createElement("canvas")
   ).current;
@@ -81,7 +82,7 @@ const _Visualizer: FunctionComponent<VisualizerProps> = ({
             hiddenCanvasElement.height
           );
           // I think this is too agressive, for later, what's Clock?
-          requestAnimationFrame(paintToMainCanvas);
+          timeout = setTimeout(paintToMainCanvas, 10);
         }
         canvasProxy({
           canvas: hiddenCanvasElement,
@@ -94,6 +95,9 @@ const _Visualizer: FunctionComponent<VisualizerProps> = ({
         paintToMainCanvas();
       }
     })();
+    return () => {
+      clearTimeout(timeout);
+    };
   }, []);
 
   useEffect(() => {

--- a/components/Visualizer/Visualizer.tsx
+++ b/components/Visualizer/Visualizer.tsx
@@ -92,7 +92,7 @@ const _Visualizer: FunctionComponent<VisualizerProps> = ({
           mode
         });
         // set up the cycle to repaint the main canvas
-        paintToMainCanvas();
+        // paintToMainCanvas();
       }
     })();
     return () => {

--- a/components/Visualizer/Visualizer.tsx
+++ b/components/Visualizer/Visualizer.tsx
@@ -67,6 +67,12 @@ const _Visualizer: FunctionComponent<VisualizerProps> = ({
       } else {
         // else use hidden canvas
         function paintToMainCanvas() {
+          mainCanvasContext.clearRect(
+            0,
+            0,
+            hiddenCanvasElement.width,
+            hiddenCanvasElement.height
+          );
           mainCanvasContext.drawImage(
             hiddenCanvasElement,
             0,
@@ -74,7 +80,7 @@ const _Visualizer: FunctionComponent<VisualizerProps> = ({
             hiddenCanvasElement.width,
             hiddenCanvasElement.height
           );
-          // I think this is too agressive, for later
+          // I think this is too agressive, for later, what's Clock?
           requestAnimationFrame(paintToMainCanvas);
         }
         canvasProxy({
@@ -114,7 +120,6 @@ const _Visualizer: FunctionComponent<VisualizerProps> = ({
           style={dimensions}
           ref={canvasRef}
         />
-
         <div className="text-white flex flex-1 absolute flex-row inset-0">
           {getNaturalKeysInRange(range).map(x => (
             <div className="vis-note-section" key={x} />

--- a/utils/keyboard.ts
+++ b/utils/keyboard.ts
@@ -3,7 +3,7 @@ import { range, findLast, find } from "lodash";
 import { Range } from "@utils/typings/Visualizer";
 import { INote } from "@typings/midi";
 import { MINIMUM_KEYS_IN_READ_MODE } from "@config/piano";
-import memoize from "@utils/memoize";
+import { memoRange, memoNumber } from "@utils/memoize";
 const pitchPositions = {
   C: 0,
   Db: 0.55,
@@ -28,27 +28,27 @@ export function isWithinRange(toCheck: number[], range: number[]) {
   return range[0] <= toCheck[0] && range[1] >= toCheck[1];
 }
 
-export const getAllMidiNumbersInRange = memoize((_range: Range): number[] => {
+export const getAllMidiNumbersInRange = memoRange((_range: Range): number[] => {
   return range(_range.first, _range.last + 1);
 });
 
-export const getNaturalKeysInRange = memoize((range: Range) => {
+export const getNaturalKeysInRange = memoRange((range: Range) => {
   return getAllMidiNumbersInRange(range).filter(
     midi => !MidiNumbers.getAttributes(midi).isAccidental
   );
 });
 
-export const getNaturalKeyWidthRatio = memoize((range: Range): number => {
+export const getNaturalKeyWidthRatio = memoRange((range: Range): number => {
   return 1 / getNaturalKeysInRange(range).length;
 });
 
-function getAbsoluteKeyPosition(midiNumber: number): number {
+const getAbsoluteKeyPosition = memoNumber((midiNumber: number): number => {
   const OCTAVE_WIDTH = 7;
   const { octave, pitchName } = MidiNumbers.getAttributes(midiNumber);
   const pitchPosition = pitchPositions[pitchName];
   const octavePosition = OCTAVE_WIDTH * octave;
   return pitchPosition + octavePosition;
-}
+});
 
 export function getRelativeKeyPosition(
   midiNumber: number,

--- a/utils/keyboard.ts
+++ b/utils/keyboard.ts
@@ -3,7 +3,7 @@ import { range, findLast, find } from "lodash";
 import { Range } from "@utils/typings/Visualizer";
 import { INote } from "@typings/midi";
 import { MINIMUM_KEYS_IN_READ_MODE } from "@config/piano";
-
+import memoize from "@utils/memoize";
 const pitchPositions = {
   C: 0,
   Db: 0.55,
@@ -28,19 +28,19 @@ export function isWithinRange(toCheck: number[], range: number[]) {
   return range[0] <= toCheck[0] && range[1] >= toCheck[1];
 }
 
-export function getAllMidiNumbersInRange(_range: Range): number[] {
+export const getAllMidiNumbersInRange = memoize((_range: Range): number[] => {
   return range(_range.first, _range.last + 1);
-}
+});
 
-export function getNaturalKeysInRange(range: Range) {
+export const getNaturalKeysInRange = memoize((range: Range) => {
   return getAllMidiNumbersInRange(range).filter(
     midi => !MidiNumbers.getAttributes(midi).isAccidental
   );
-}
+});
 
-export function getNaturalKeyWidthRatio(range: Range): number {
+export const getNaturalKeyWidthRatio = memoize((range: Range): number => {
   return 1 / getNaturalKeysInRange(range).length;
-}
+});
 
 function getAbsoluteKeyPosition(midiNumber: number): number {
   const OCTAVE_WIDTH = 7;

--- a/utils/memoize.ts
+++ b/utils/memoize.ts
@@ -1,0 +1,13 @@
+import { Range } from "./typings/Visualizer";
+
+type Fn<T> = (range: Range) => T;
+
+const getKey = ({ first, last }: Range) => `${first}-${last}`;
+
+const memo = <T>(fn: Fn<T>) => (range: Range) => {
+  const cache = {};
+  const key = getKey(range);
+  return cache[key] ? cache[key] : ((cache[key] = fn(range)), cache[key]);
+};
+
+export default memo;

--- a/utils/memoize.ts
+++ b/utils/memoize.ts
@@ -1,13 +1,17 @@
 import { Range } from "./typings/Visualizer";
 
 type Fn<T> = (range: Range) => T;
+type FnNum<T> = (num: number) => T;
 
 const getKey = ({ first, last }: Range) => `${first}-${last}`;
 
-const memo = <T>(fn: Fn<T>) => (range: Range) => {
+export const memoRange = <T>(fn: Fn<T>) => (range: Range) => {
   const cache = {};
   const key = getKey(range);
   return cache[key] ? cache[key] : ((cache[key] = fn(range)), cache[key]);
 };
 
-export default memo;
+export const memoNumber = <T>(fn: FnNum<T>) => (num: number) => {
+  const cache = {};
+  return cache[num] ? cache[num] : (cache[num] = fn(num)), cache[num];
+};

--- a/utils/updateLoop.ts
+++ b/utils/updateLoop.ts
@@ -1,0 +1,36 @@
+const fakeRAF = fn => setTimeout(fn, 8);
+
+const updateLoop = fn => {
+  let lastRunTimestamp = 0;
+  let timeoutPointer: NodeJS.Timer;
+  let accumulatedTime = 0;
+  const timeStep = 1000 / 30;
+
+  const run = () => {
+    timeoutPointer = fakeRAF(run);
+
+    const now = performance.now();
+    accumulatedTime += now - lastRunTimestamp;
+    if (accumulatedTime >= timeStep * 3) {
+      accumulatedTime = timeStep;
+    }
+
+    while (accumulatedTime >= timeStep) {
+      accumulatedTime -= timeStep;
+      fn();
+    }
+  };
+
+  return {
+    start() {
+      accumulatedTime = timeStep;
+      lastRunTimestamp = performance.now();
+      timeoutPointer = fakeRAF(run);
+    },
+    stop() {
+      clearTimeout(timeoutPointer);
+    }
+  };
+};
+
+export default updateLoop;

--- a/utils/visualizerControl.ts
+++ b/utils/visualizerControl.ts
@@ -7,9 +7,7 @@ import { Dimensions, Range } from "@utils/typings/Visualizer";
 import { ITrack } from "@typings/midi";
 
 export interface IData {
-  canvas: {
-    getContext: (x: string) => CanvasRenderingContext2D;
-  };
+  canvas: HTMLCanvasElement;
   track: ITrack;
   message: VISUALIZER_MESSAGES;
   range: Range;


### PR DESCRIPTION
<img width="972" alt="Screenshot 2019-10-02 at 10 32 40 PM" src="https://user-images.githubusercontent.com/6652823/66065232-97eea300-e564-11e9-9d5e-584857f7f168.png">

So I played with this app a bit. To support OffScreenCanvas, I tried using an in-memory canvas (not drawn on the main screen) to draw and copy it to main screen. I think it mostly works, but somehow I see long continuous bars and not exact notes. I'm guessing it's not able to reset the buffer canvas. Attached an image.

Will update this.
