### PR TITLE
format: add prettier config file

### DIFF
--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,3 @@
+{
+  "trailingComma": "none"
+}

--- a/hooks/useOnClickOutside.ts
+++ b/hooks/useOnClickOutside.ts
@@ -1,25 +1,27 @@
 import { useEffect } from "react";
 
 export function useOnClickOutside(ref, handler) {
-  useEffect(() => {
-    const listener = event => {
-      // Do nothing if clicking ref's element or descendent elements
-      if (!ref.current || ref.current.contains(event.target)) {
-        return;
-      }
+  useEffect(
+    () => {
+      const listener = event => {
+        // Do nothing if clicking ref's element or descendent elements
+        if (!ref.current || ref.current.contains(event.target)) {
+          return;
+        }
 
-      handler(event);
-    };
+        handler(event);
+      };
 
-    document.addEventListener("mousedown", listener);
-    document.addEventListener("touchstart", listener);
+      document.addEventListener("mousedown", listener);
+      document.addEventListener("touchstart", listener);
 
-    return () => {
-      document.removeEventListener("mousedown", listener);
-      document.removeEventListener("touchstart", listener);
-    };
-  }, // ... callback/cleanup to run every render. It's not a big deal ... // ... function on every render that will cause this effect ... // It's worth noting that because passed in handler is a new ... // Add ref and handler to effect dependencies
-  // ... but to optimize you can wrap handler in useCallback before ...
-  // ... passing it into this hook.
-  [ref, handler]);
+      return () => {
+        document.removeEventListener("mousedown", listener);
+        document.removeEventListener("touchstart", listener);
+      };
+    }, // ... callback/cleanup to run every render. It's not a big deal ... // ... function on every render that will cause this effect ... // It's worth noting that because passed in handler is a new ... // Add ref and handler to effect dependencies
+    // ... but to optimize you can wrap handler in useCallback before ...
+    // ... passing it into this hook.
+    [ref, handler]
+  );
 }

--- a/utils/MidiPlayer/MidiPlayer.ts
+++ b/utils/MidiPlayer/MidiPlayer.ts
@@ -107,7 +107,7 @@ export class MidiPlayer {
   }) => {
     const { instrumentIds, drums } = {
       instrumentIds:
-        (options?.instrumentIds) ||
+        options?.instrumentIds ||
         this.midi.tracks
           .map(track => track.instrument && track.instrument.number)
           .filter(Boolean),


### PR DESCRIPTION
Adding [prettier configuration file](https://prettier.io/docs/en/configuration.html) to ensure that the same settings always get applied. There were 2 files that did not follow the format and they are fixed with `yarn format`.