### PR TITLE
feat: add range presets, change default range, and make range preference persistent

### DIFF
--- a/components/PianoRangeSelector/PianoRangeSelector.tsx
+++ b/components/PianoRangeSelector/PianoRangeSelector.tsx
@@ -52,76 +52,85 @@ const _PianoRangeSelector: FunctionComponent<PianoRangeSelectorProps> = ({
           </Button>
         )}
       >
-        {close => (
+        {() => (
           <div className="prs-content">
-            <div className="text-sm text-white mb-2">Piano Range Selector</div>
-            {RANGE_PRESETS.map(({ first, last }) => {
-              const [presetMin, presetMax] = [
-                indexOfMidiNumber(first),
-                indexOfMidiNumber(last)
-              ];
-              return (
-                <div
-                  className={cn("keyboard-layout-list", {
-                    selected: presetMin === _range[0] && presetMax === _range[1]
-                  })}
-                  key={`${first}-${last}`}
-                  onClick={() => {
-                    setRange([presetMin, presetMax]);
-                    close();
-                  }}
-                >
-                  <div className="px-2" style={{ width: 60 }}>
-                    {last - first + 1} keys
-                  </div>
-                  <div className="px-2 flex items-center">
-                    {MidiNumbers.getAttributes(first).note}
-                    <Icon name="minus" color="#fff" size={8} className="mx-2" />
-                    {MidiNumbers.getAttributes(last).note}
-                  </div>
-                </div>
-              );
-            })}
-
-            <div>
-              <RangeSlider
-                step={1}
-                min={0}
-                max={naturalKeys.length - 1}
-                values={_range}
-                onChange={setRange}
-                renderTrack={({ props, children }) => (
-                  <div
-                    onMouseDown={props.onMouseDown as any}
-                    onTouchStart={props.onTouchStart}
-                    className="h-10 flex w-full"
-                    style={props.style}
-                  >
+            <div className="py-1">
+              <div className="text-sm text-white mb-1">Presets</div>
+              <div className="flex">
+                {RANGE_PRESETS.map(({ first, last }) => {
+                  const [presetMin, presetMax] = [
+                    indexOfMidiNumber(first),
+                    indexOfMidiNumber(last)
+                  ];
+                  return (
                     <div
-                      ref={props.ref}
-                      className="h-1 w-full self-center rounded"
-                      style={{
-                        background: getTrackBackground({
-                          values: _range,
-                          colors: ["#ccc", "#2196f3", "#ccc"],
-                          min: 0,
-                          max: naturalKeys.length - 1
-                        })
+                      className={cn("keyboard-layout-list mx-1", {
+                        selected:
+                          presetMin === _range[0] && presetMax === _range[1]
+                      })}
+                      key={`${first}-${last}`}
+                      onClick={() => {
+                        setRange([presetMin, presetMax]);
                       }}
                     >
-                      {children}
+                      <div className="flex items-center">
+                        {MidiNumbers.getAttributes(first).note}
+                        <Icon
+                          name="minus"
+                          color="#fff"
+                          size={8}
+                          className="mx-1"
+                        />
+                        {MidiNumbers.getAttributes(last).note}
+                      </div>
+                      <div className="text-center">{last - first + 1} keys</div>
                     </div>
-                  </div>
-                )}
-                renderThumb={({ index, props }) => (
-                  <div {...props} style={props.style}>
-                    <div className="prs-thumb" />
-                    <span className="prs-label">
-                      {naturalKeys[_range[index]].label}
-                    </span>
-                  </div>
-                )}
-              />
+                  );
+                })}
+              </div>
+            </div>
+            <div className="py-2">
+              <div className="text-sm text-white mb-1">Custom</div>
+              <div>
+                <RangeSlider
+                  step={1}
+                  min={0}
+                  max={naturalKeys.length - 1}
+                  values={_range}
+                  onChange={setRange}
+                  renderTrack={({ props, children }) => (
+                    <div
+                      onMouseDown={props.onMouseDown as any}
+                      onTouchStart={props.onTouchStart}
+                      className="h-10 flex w-full"
+                      style={props.style}
+                    >
+                      <div
+                        ref={props.ref}
+                        className="h-1 w-full self-center rounded"
+                        style={{
+                          background: getTrackBackground({
+                            values: _range,
+                            colors: ["#ccc", "#2196f3", "#ccc"],
+                            min: 0,
+                            max: naturalKeys.length - 1
+                          })
+                        }}
+                      >
+                        {children}
+                      </div>
+                    </div>
+                  )}
+                  renderThumb={({ index, props }) => (
+                    <div {...props} style={props.style}>
+                      <div className="prs-thumb" />
+                      <span className="prs-label">
+                        {naturalKeys[_range[index]].label}
+                      </span>
+                    </div>
+                  )}
+                />
+              </div>
             </div>
           </div>
         )}

--- a/components/PianoRangeSelector/PianoRangeSelector.tsx
+++ b/components/PianoRangeSelector/PianoRangeSelector.tsx
@@ -1,7 +1,9 @@
 import React, { FunctionComponent, memo, useState } from "react";
+import cn from "@sindresorhus/class-names";
 import { Button } from "@components/Button";
 import { MidiNumbers } from "piano-utils";
 import { Icon } from "@components/Icon";
+import { RANGE_PRESETS } from "@config/piano";
 import { Range } from "@utils/typings/Visualizer";
 import { Dropdown } from "@components/Dropdown";
 import { getTrackBackground, Range as RangeSlider } from "react-range";
@@ -19,13 +21,17 @@ const naturalKeys = MidiNumbers.NATURAL_MIDI_NUMBERS.map(midi => {
   };
 });
 
+const indexOfMidiNumber = (midiNumber: number): number =>
+  naturalKeys.findIndex(({ value }) => value === midiNumber);
+
 const _PianoRangeSelector: FunctionComponent<PianoRangeSelectorProps> = ({
   range,
   onRangeChange
 }) => {
-  const min = naturalKeys.findIndex(key => key.value === range.first);
-  const max = naturalKeys.findIndex(key => key.value === range.last);
-  const [_range, _setRange] = useState([min, max]);
+  const [_range, _setRange] = useState([
+    indexOfMidiNumber(range.first),
+    indexOfMidiNumber(range.last)
+  ]);
 
   const setRange = (range_: number[]) => {
     onRangeChange([naturalKeys[range_[0]].value, naturalKeys[range_[1]].value]);
@@ -46,9 +52,36 @@ const _PianoRangeSelector: FunctionComponent<PianoRangeSelectorProps> = ({
           </Button>
         )}
       >
-        {() => (
+        {close => (
           <div className="prs-content">
             <div className="text-sm text-white mb-2">Piano Range Selector</div>
+            {RANGE_PRESETS.map(({ first, last }) => {
+              const [presetMin, presetMax] = [
+                indexOfMidiNumber(first),
+                indexOfMidiNumber(last)
+              ];
+              return (
+                <div
+                  className={cn("keyboard-layout-list", {
+                    selected: presetMin === _range[0] && presetMax === _range[1]
+                  })}
+                  key={`${first}-${last}`}
+                  onClick={() => {
+                    setRange([presetMin, presetMax]);
+                    close();
+                  }}
+                >
+                  <div className="px-2" style={{ width: 60 }}>
+                    {last - first + 1} keys
+                  </div>
+                  <div className="px-2 flex items-center">
+                    {MidiNumbers.getAttributes(first).note}
+                    <Icon name="minus" color="#fff" size={8} className="mx-2" />
+                    {MidiNumbers.getAttributes(last).note}
+                  </div>
+                </div>
+              );
+            })}
 
             <div>
               <RangeSlider

--- a/components/PianoRangeSelector/piano-range-selector.css
+++ b/components/PianoRangeSelector/piano-range-selector.css
@@ -1,6 +1,6 @@
 .prs-content {
   @apply text-white text-xs px-4 py-4 pb-8;
-  width: 300px;
+  width: 440px;
 }
 
 .prs-label {

--- a/components/SoundPlayer.tsx
+++ b/components/SoundPlayer.tsx
@@ -15,11 +15,7 @@ import { getInstrumentIdByValue, instruments } from "midi-instruments";
 import { VISUALIZER_MODE } from "@enums/visualizerMessages";
 import webMidi from "webmidi";
 import Tone from "tone";
-import {
-  PIANO_HEIGHT,
-  DEFAULT_FIRST_KEY,
-  DEFAULT_LAST_KEY
-} from "@config/piano";
+import { PIANO_HEIGHT, getDefaultRange, setDefaultRange } from "@config/piano";
 import { IMidiJSON } from "@typings/midi";
 import { GlobalHeader } from "@components/GlobalHeader";
 import { MidiSettings } from "@components/TrackList";
@@ -32,18 +28,13 @@ import { wrap } from "comlink";
 import CanvasWorker from "@workers/canvas.worker";
 import { controlVisualizer } from "@utils/visualizerControl";
 
-const range = {
-  first: DEFAULT_FIRST_KEY,
-  last: DEFAULT_LAST_KEY
-};
-
 const SoundPlayer: React.FunctionComponent<{
   offScreenCanvasSupport: OFFSCREEN_2D_CANVAS_SUPPORT;
 }> = ({ offScreenCanvasSupport }) => {
   const [instrument, setInstrument] = useState(instruments[0].value);
   const [loading, setLoading] = useState(false);
   const [activeMidis, setActiveMidis] = useState<number[]>([]);
-  const [keyboardRange, setKeyboardRange] = useState<Range>(range);
+  const [keyboardRange, setKeyboardRange] = useState<Range>(getDefaultRange());
   const [isPlaying, setPlaying] = useState(false);
   const [mode, setMode] = useState<VISUALIZER_MODE>(VISUALIZER_MODE.WRITE);
   const [midiSettings, setMidiSettings] = useState<MidiSettings>(null);
@@ -81,7 +72,9 @@ const SoundPlayer: React.FunctionComponent<{
       // change piano range.
       const requiredRange = getMidiRange(notes);
 
-      if (!isWithinRange(requiredRange, [range.first, range.last])) {
+      if (
+        !isWithinRange(requiredRange, [keyboardRange.first, keyboardRange.last])
+      ) {
         const _range = getPianoRangeAndShortcuts(requiredRange).range;
         setKeyboardRange(_range);
         setPlaying(true);
@@ -90,7 +83,7 @@ const SoundPlayer: React.FunctionComponent<{
 
       return keyboardRange;
     },
-    [range]
+    [keyboardRange]
   );
 
   const onNoteStart = useCallback(
@@ -224,6 +217,7 @@ const SoundPlayer: React.FunctionComponent<{
   const handleRangeChange = useCallback(
     _range => {
       const { range } = getPianoRangeAndShortcuts(_range, false);
+      setDefaultRange(range);
       player.setRange(range);
       setKeyboardRange(range);
     },

--- a/config/piano.ts
+++ b/config/piano.ts
@@ -10,6 +10,15 @@ export const RADIUS = 3;
 export const GLOBAL_HEADER_HEIGHT = 50;
 export const MINIMUM_KEYS_IN_READ_MODE = 40;
 
+export const RANGE_PRESETS: Range[] = [
+  { first: 48, last: 72 }, // 25 keys: C3 - C5
+  { first: 41, last: 72 }, // 32 keys: F2 - C5
+  { first: 48, last: 84 }, // 37 keys: C3 - C6
+  { first: 36, last: 84 }, // 49 keys: C2 - C6
+  { first: 36, last: 96 }, // 61 keys: C2 - C7
+  { first: 21, last: 108 } // 88 keys: A0 - C8
+];
+
 const DEFAULT_RANGE: Range = { first: 36, last: 84 }; // 49 keys: C2 - C6
 
 export const getDefaultRange = (): Range => {

--- a/config/piano.ts
+++ b/config/piano.ts
@@ -1,3 +1,5 @@
+import { Range } from "@utils/typings/Visualizer";
+
 export const TRACK_PLAYING_SPEED = 100;
 export const HORIZONTAL_GAP_BETWEEN_NOTES = 2;
 export const MS_PER_SECOND = 10;
@@ -7,5 +9,19 @@ export const NATURAL_KEY_COLOR = "#42C9FF";
 export const RADIUS = 3;
 export const GLOBAL_HEADER_HEIGHT = 50;
 export const MINIMUM_KEYS_IN_READ_MODE = 40;
-export const DEFAULT_FIRST_KEY = 38;
-export const DEFAULT_LAST_KEY = 88;
+
+const DEFAULT_RANGE: Range = { first: 36, last: 84 }; // 49 keys: C2 - C6
+
+export const getDefaultRange = (): Range => {
+  const range = window.localStorage.getItem("range");
+  if (range) {
+    try {
+      const { first, last } = JSON.parse(range);
+      return { first, last };
+    } catch (e) {}
+  }
+  return DEFAULT_RANGE;
+};
+
+export const setDefaultRange = (range: Range) =>
+  window.localStorage.setItem("range", JSON.stringify(range));

--- a/styles/mixins.css
+++ b/styles/mixins.css
@@ -6,16 +6,19 @@
   -webkit-font-smoothing: antialiased;
 }
 
-.instrument-list {
+.instrument-list,
+.keyboard-layout-list {
   @apply text-xs px-3 py-1 cursor-pointer flex flex-row items-center;
 }
 
-.instrument-list:hover {
+.instrument-list:hover,
+.keyboard-layout-list:hover {
   color: #ffffff;
   background-color: #1b1b1b;
 }
 
-.instrument-list.selected {
+.instrument-list.selected,
+.keyboard-layout-list.selected {
   background-color: #3f51b5;
 }
 

--- a/styles/mixins.css
+++ b/styles/mixins.css
@@ -11,6 +11,11 @@
   @apply text-xs px-3 py-1 cursor-pointer flex flex-row items-center;
 }
 
+.keyboard-layout-list {
+  @apply flex-col px-2 rounded-sm;
+  width: 60px;
+}
+
 .instrument-list:hover,
 .keyboard-layout-list:hover {
   color: #ffffff;

--- a/utils/PlayerContext.ts
+++ b/utils/PlayerContext.ts
@@ -1,12 +1,7 @@
-import { DEFAULT_FIRST_KEY, DEFAULT_LAST_KEY } from "@config/piano";
+import { getDefaultRange } from "@config/piano";
 import { MidiPlayer } from "@utils/MidiPlayer";
 import React from "react";
 
-const range = {
-  first: DEFAULT_FIRST_KEY,
-  last: DEFAULT_LAST_KEY
-};
-
-export const player = new MidiPlayer(range);
+export const player = new MidiPlayer(getDefaultRange());
 
 export const PlayerContext = React.createContext(player);


### PR DESCRIPTION
Add the following features for the piano range:
- Add the most common keyboard layout as range presets:
  - 25 keys: `C3-C5`
  - 32 keys: `F2-C5`
  - 37 keys: `C3-C6`
  - 49 keys: `C2-C6`
  - 61 keys: `C2-C7`
  - 88 keys: `A0-C8`
- Changed the default range from `D2-E6` (51 keys) to `C2-C6` (49 keys layout, which is common)
- Store user's choice in `window.localStorage`


![Screenshot 2020-08-02 22 41 06](https://user-images.githubusercontent.com/5341184/89150069-968a6000-d512-11ea-8782-e7fca468ddbd.png)
