### PR TITLE
feat: piano keyboard style tweaks

### DIFF
--- a/components/Piano/Piano.tsx
+++ b/components/Piano/Piano.tsx
@@ -59,7 +59,7 @@ const _Piano: FunctionComponent<PianoProps> = ({
   return (
     <div
       className={cn(
-        "flex justify-center w-full relative overflow-x-hidden",
+        "flex justify-center w-full h-full relative overflow-x-hidden",
         className
       )}
     >

--- a/components/Piano/piano.css
+++ b/components/Piano/piano.css
@@ -4,30 +4,29 @@
 }
 
 .natural-keys {
-  @apply z-0 border border-gray-700 border-t-0 rounded-b-sm bg-white flex flex-1 cursor-pointer keys;
+  @apply z-0 border border-gray-700 border-t-0 rounded-b-lg bg-white flex flex-1 cursor-pointer keys;
   width: auto !important;
-  height: 210px;
+  height: 100%;
   border-bottom: 4px solid #90caf9;
 }
 
 .natural-keys.__active__ {
-  height: 205px;
-  background-image: linear-gradient(#42c9ff, #28e6ff);
-  border-bottom-color: #42c9ff;
+  background-image: linear-gradient(#42c9ff, #3bb4e5);
+  border-bottom: 2px solid #277899;
 }
 
 .accidental-keys {
-  @apply h-24 z-10 border border-black rounded-b-sm bg-black bg-gray-800 absolute top-0 cursor-pointer keys;
+  @apply z-10 border border-black rounded-b-sm bg-black bg-gray-800 absolute top-0 cursor-pointer keys;
+  height: 60%;
   box-shadow: -1px -1px 2px rgba(255, 255, 255, 0.2) inset,
     0 -5px 2px 3px rgba(0, 0, 0, 0.6) inset, 0 2px 4px rgba(0, 0, 0, 0.5);
 }
 
 .accidental-keys.__active__ {
-  height: 5.8rem;
   background-image: linear-gradient(#fbd95c, #fbcf32);
   border-color: #b49b45;
   box-shadow: -1px -1px 2px rgba(255, 255, 255, 0.2) inset,
-    0 -5px 2px 3px rgba(0, 0, 0, 0.2) inset, 0 2px 4px rgba(0, 0, 0, 0.2);
+    0 0 2px 3px rgba(0, 0, 0, 0.2) inset, 0 2px 4px rgba(0, 0, 0, 0.2);
 }
 
 .bingo {

--- a/components/SoundPlayer.tsx
+++ b/components/SoundPlayer.tsx
@@ -15,7 +15,11 @@ import { getInstrumentIdByValue, instruments } from "midi-instruments";
 import { VISUALIZER_MODE } from "@enums/visualizerMessages";
 import webMidi from "webmidi";
 import Tone from "tone";
-import { DEFAULT_FIRST_KEY, DEFAULT_LAST_KEY } from "@config/piano";
+import {
+  PIANO_HEIGHT,
+  DEFAULT_FIRST_KEY,
+  DEFAULT_LAST_KEY
+} from "@config/piano";
 import { IMidiJSON } from "@typings/midi";
 import { GlobalHeader } from "@components/GlobalHeader";
 import { MidiSettings } from "@components/TrackList";
@@ -259,7 +263,7 @@ const SoundPlayer: React.FunctionComponent<{
           offScreenCanvasSupport={offScreenCanvasSupport}
         />
       </div>
-      <div className="piano-wrapper">
+      <div className="piano-wrapper" style={{ height: PIANO_HEIGHT }}>
         {loading && <Loader className="absolute z-10 h-4" />}
         <Piano
           activeMidis={activeMidis}

--- a/styles/index.css
+++ b/styles/index.css
@@ -29,5 +29,4 @@
 
 .piano-wrapper {
   @apply flex justify-center relative items-center border-t border-black;
-  height: var(--piano-height);
 }

--- a/styles/variables.css
+++ b/styles/variables.css
@@ -1,5 +1,4 @@
 :root {
-  --piano-height: 210px;
   --global-header-height: 50px;
   --horizontal-gap-between-notes: 2px;
 }


### PR DESCRIPTION
More realistic key styles

- Tweak the visible lengths of the black keys such that the ratio of the black key length and the white key length is 0.6.
- Tweak the pressed state of the black keys
- Tweak the pressed state of the white keys.
- Increase the rounded corner radius of the white keys.

Before:
![Screenshot 2020-08-03 07 34 40](https://user-images.githubusercontent.com/5341184/89195208-48e71500-d55d-11ea-87c2-e3f91eb6ef0a.png)
![Screenshot 2020-08-03 07 34 55](https://user-images.githubusercontent.com/5341184/89195260-61572f80-d55d-11ea-8c6b-dc8b63a6f1c7.png)


After:
![Screenshot 2020-08-03 08 28 53](https://user-images.githubusercontent.com/5341184/89199589-9ebebb80-d563-11ea-91c1-e01247538692.png)
![Screenshot 2020-08-03 08 29 20](https://user-images.githubusercontent.com/5341184/89199598-a1b9ac00-d563-11ea-8ad1-f9af60f4c9ec.png)

