### PR TITLE
feat(keyboard): support playing with a computer keyboard

### DIFF
--- a/components/SoundPlayer.tsx
+++ b/components/SoundPlayer.tsx
@@ -33,6 +33,7 @@ import { ThemeContext } from "@utils/ThemeContext";
 import { wrap } from "comlink";
 import CanvasWorker from "@workers/canvas.worker";
 import { controlVisualizer } from "@utils/visualizerControl";
+import { useKeyboardShortcuts } from "@utils/keyboardShortcuts";
 
 const SoundPlayer: React.FunctionComponent<{
   offScreenCanvasSupport: OFFSCREEN_2D_CANVAS_SUPPORT;
@@ -120,6 +121,8 @@ const SoundPlayer: React.FunctionComponent<{
     },
     [player, mode, instrument]
   );
+
+  useKeyboardShortcuts(onNoteStart, onNoteStop);
 
   useEffect(() => {
     if (loadedMidi && midiSettings) {

--- a/utils/keyboardShortcuts.ts
+++ b/utils/keyboardShortcuts.ts
@@ -29,19 +29,19 @@ export const useKeyboardShortcuts = (
   onPlay: (midi: number) => void,
   onStop: (midi: number) => void
 ) => {
-  const activeMidiMapRef = useRef(new Set());
+  const activeMidisRef = useRef(new Set());
   useEffect(() => {
     const handleKeyDown = (event: KeyboardEvent) => {
       const midi = keyboardEventToMidi(event);
-      if (midi && !activeMidiMapRef.current.has(midi)) {
-        activeMidiMapRef.current.add(midi);
+      if (midi && !activeMidisRef.current.has(midi)) {
+        activeMidisRef.current.add(midi);
         onPlay(midi);
       }
     };
     const handleKeyUp = (event: KeyboardEvent) => {
       const midi = keyboardEventToMidi(event);
-      if (midi && activeMidiMapRef.current.has(midi)) {
-        activeMidiMapRef.current.delete(midi);
+      if (midi && activeMidisRef.current.has(midi)) {
+        activeMidisRef.current.delete(midi);
         onStop(midi);
       }
     };

--- a/utils/keyboardShortcuts.ts
+++ b/utils/keyboardShortcuts.ts
@@ -1,0 +1,55 @@
+import { useEffect, useRef } from "react";
+
+const KEY_TO_MIDI = {
+  a: 60,
+  w: 61,
+  s: 62,
+  e: 63,
+  d: 64,
+  f: 65,
+  t: 66,
+  g: 67,
+  y: 68,
+  h: 69,
+  u: 70,
+  j: 71,
+  k: 72
+};
+
+const keyboardEventToOctaveOffset = (event: KeyboardEvent): number => {
+  return event.shiftKey ? 12 : event.ctrlKey ? -12 : 0;
+};
+
+const keyboardEventToMidi = (event: KeyboardEvent): number | null => {
+  const midi = KEY_TO_MIDI[event.key.toLowerCase()];
+  return midi ? midi + keyboardEventToOctaveOffset(event) : null;
+};
+
+export const useKeyboardShortcuts = (
+  onPlay: (midi: number) => void,
+  onStop: (midi: number) => void
+) => {
+  const activeMidiMapRef = useRef(new Set());
+  useEffect(() => {
+    const handleKeyDown = (event: KeyboardEvent) => {
+      const midi = keyboardEventToMidi(event);
+      if (midi && !activeMidiMapRef.current.has(midi)) {
+        activeMidiMapRef.current.add(midi);
+        onPlay(midi);
+      }
+    };
+    const handleKeyUp = (event: KeyboardEvent) => {
+      const midi = keyboardEventToMidi(event);
+      if (midi && activeMidiMapRef.current.has(midi)) {
+        activeMidiMapRef.current.delete(midi);
+        onStop(midi);
+      }
+    };
+    document.addEventListener("keydown", handleKeyDown);
+    document.addEventListener("keyup", handleKeyUp);
+    return () => {
+      document.removeEventListener("keydown", handleKeyDown);
+      document.removeEventListener("keyup", handleKeyUp);
+    };
+  }, [onPlay, onStop]);
+};

--- a/utils/keyboardShortcuts.ts
+++ b/utils/keyboardShortcuts.ts
@@ -16,13 +16,13 @@ const KEY_TO_MIDI = {
   k: 72
 };
 
-const keyboardEventToOctaveOffset = (event: KeyboardEvent): number => {
-  return event.shiftKey ? 12 : event.ctrlKey ? -12 : 0;
-};
+const OCTAVE_SEMITONES = 12;
 
 const keyboardEventToMidi = (event: KeyboardEvent): number | null => {
   const midi = KEY_TO_MIDI[event.key.toLowerCase()];
-  return midi ? midi + keyboardEventToOctaveOffset(event) : null;
+  return midi
+    ? midi + (event.shiftKey ? 1 : event.ctrlKey ? -1 : 0) * OCTAVE_SEMITONES
+    : null;
 };
 
 export const useKeyboardShortcuts = (

--- a/utils/keyboardShortcuts.ts
+++ b/utils/keyboardShortcuts.ts
@@ -1,28 +1,34 @@
 import { useEffect, useRef } from "react";
 
+// QWERTY keyboard shortcut to MIDI number
 const KEY_TO_MIDI = {
-  a: 60,
-  w: 61,
-  s: 62,
-  e: 63,
-  d: 64,
-  f: 65,
-  t: 66,
-  g: 67,
-  y: 68,
-  h: 69,
-  u: 70,
-  j: 71,
-  k: 72
+  a: 60, // C4 in scientific pitch notation https://en.wikipedia.org/wiki/Scientific_pitch_notation#Table_of_note_frequencies
+  w: 61, // D♭4
+  s: 62, // D4
+  e: 63, // E♭4
+  d: 64, // E4
+  f: 65, // F4
+  t: 66, // G♭4
+  g: 67, // G4
+  y: 68, // A♭4
+  h: 69, // A4
+  u: 70, // B♭4
+  j: 71, // B4
+  k: 72 // C5
 };
 
-const OCTAVE_SEMITONES = 12;
+const OCTAVE_SEMITONES = 12; // there are 12 semitones in an octave
 
 const keyboardEventToMidi = (event: KeyboardEvent): number | null => {
-  const midi = KEY_TO_MIDI[event.key.toLowerCase()];
-  return midi
-    ? midi + (event.shiftKey ? 1 : event.ctrlKey ? -1 : 0) * OCTAVE_SEMITONES
-    : null;
+  const midi = KEY_TO_MIDI[event.key.toLowerCase()]; // C4 ~ C5 (e.g. The keyboard shortcut `a` is mapped to C4)
+  if (!midi) {
+    return null;
+  }
+  // hold the Shift key to raise the note by one octave (e.g. the keyboard shortcut `Shift+a` is mapped to C5)
+  // hold the Control key to lower the note by one octave (e.g. the keyboard shortcut `Ctrl+a` is mapped to C3)
+  return (
+    midi + (event.shiftKey ? 1 : event.ctrlKey ? -1 : 0) * OCTAVE_SEMITONES
+  );
 };
 
 export const useKeyboardShortcuts = (


### PR DESCRIPTION
Inspired by the "Musical Typing" in Logic Pro X:
![Screen Shot 2020-08-09 at 3 24 30 AM](https://user-images.githubusercontent.com/5341184/89730028-e4f69d80-d9ef-11ea-83ad-6ef65efbd78c.png)

Here is the QWERTY keyboard shortcut layout:

![Screen Shot 2020-08-09 at 6 53 26 PM](https://user-images.githubusercontent.com/5341184/89747312-15cbe680-da73-11ea-972e-cd4c25c55c56.png)

- `a` ~ `k` is C4 ~ C5.
- `a` ~ `k` with the control key is C3 ~ C4. In other words, the control key lowers one octave.
- `a` ~ `k` with the shift key is C5 ~ C6. In other words, the shift key raises one octave.

Therefore, the computer keyboard shortcut range is C3 ~ C6.
