### PR TITLE
feat: Add volume slider

### DIFF
--- a/components/Header/Header.tsx
+++ b/components/Header/Header.tsx
@@ -11,6 +11,7 @@ import { Midi } from "@utils/Midi/Midi";
 import { INoteSequence } from "@magenta/music";
 import Icon from "@mdi/react";
 import { mdiVolumeHigh, mdiVolumeOff } from "@mdi/js";
+import { VolumeSlider } from "@components/Header/VolumeSlider";
 
 type HeaderProps = React.ComponentProps<typeof ReadModeControls> &
   React.ComponentProps<typeof WriteModeControls> & {
@@ -20,6 +21,8 @@ type HeaderProps = React.ComponentProps<typeof ReadModeControls> &
     midiDeviceId: string;
     onMidiDeviceChange: (midiDevice: string) => void;
     onThemeChange: (theme: Theme) => void;
+    onVolumeChange: (volume: number) => void;
+    volume: number;
     isLoading: boolean;
   };
 
@@ -36,6 +39,8 @@ const _Header: React.FunctionComponent<HeaderProps> = ({
   onRangeChange,
   onMidiDeviceChange,
   onThemeChange,
+  onVolumeChange,
+  volume,
   midiSettings,
   isLoading
 }) => {
@@ -76,13 +81,22 @@ const _Header: React.FunctionComponent<HeaderProps> = ({
       </div>
 
       <div className="flex flex-row justify-between items-center">
-        <Icon
-          path={volumeName}
-          color={"#fff"}
-          onClick={_toggleMute}
-          className="mx-4 cursor-pointer"
-          size={1}
-        />
+        <div className="flex flex-row mx-1 items-center">
+          <Icon
+            path={volumeName}
+            color={"#fff"}
+            onClick={_toggleMute}
+            className="cursor-pointer"
+            size={1}
+          />
+          <div className="px-4">
+            <VolumeSlider
+              disabled={mute}
+              onVolumeChange={onVolumeChange}
+              volume={volume}
+            />
+          </div>
+        </div>
 
         <MidiSelect
           onMidiDeviceChange={onMidiDeviceChange}

--- a/components/Header/VolumeSlider.tsx
+++ b/components/Header/VolumeSlider.tsx
@@ -1,0 +1,57 @@
+import React, { FunctionComponent } from "react";
+import { getTrackBackground, Range as RangeSlider } from "react-range";
+
+interface VolumeSliderProps {
+  disabled: boolean;
+  onVolumeChange: (volume: number) => void;
+  volume: number;
+}
+
+const VOLUME_MIN = -10;
+const VOLUME_MAX = 10;
+
+export const VolumeSlider: FunctionComponent<VolumeSliderProps> = ({
+  disabled,
+  onVolumeChange,
+  volume
+}) => {
+  return (
+    <RangeSlider
+      step={1}
+      min={VOLUME_MIN}
+      max={VOLUME_MAX}
+      values={[volume]}
+      disabled={disabled}
+      onChange={values => onVolumeChange(values[0])}
+      renderTrack={({ props, children }) => (
+        <div
+          onMouseDown={props.onMouseDown as any}
+          onTouchStart={props.onTouchStart}
+          className="h-10 flex"
+          style={{ ...props.style, opacity: disabled ? 0.5 : 1 }}
+        >
+          <div
+            ref={props.ref}
+            className="h-1 w-full self-center rounded"
+            style={{
+              width: 120,
+              background: getTrackBackground({
+                values: [volume],
+                colors: ["#2196f3", "#ccc"],
+                min: VOLUME_MIN,
+                max: VOLUME_MAX
+              })
+            }}
+          >
+            {children}
+          </div>
+        </div>
+      )}
+      renderThumb={({ props }) => (
+        <div {...props} style={props.style}>
+          <div className="prs-thumb" />
+        </div>
+      )}
+    />
+  );
+};

--- a/components/SoundPlayer.tsx
+++ b/components/SoundPlayer.tsx
@@ -54,6 +54,7 @@ const SoundPlayer: React.FunctionComponent<{
   const [midiDevice, setSelectedMidiDevice] = useState(null);
   const [activeInstrumentMidis, setActiveInstrumentMidis] = useState([]);
   const [theme, setTheme] = useState(DEFAULT_THEME);
+  const [volume, setVolume] = useState(0); // Unit is dB, which is logarithmic. 0 means no changes. -10/+10 is about half/twice as loud.
   const staffVisualiserRef = useRef<HTMLDivElement>(null);
 
   const canvasProxyRef = useRef<any>(
@@ -72,13 +73,14 @@ const SoundPlayer: React.FunctionComponent<{
       (async () => {
         setLoading(true);
         await player.loadInstruments({
-          instrumentIds: [getInstrumentIdByValue(_instrument)]
+          instrumentIds: [getInstrumentIdByValue(_instrument)],
+          volume
         });
         setInstrument(_instrument);
         setLoading(false);
       })();
     },
-    [player]
+    [player, volume]
   );
 
   const setRange = useCallback(
@@ -154,7 +156,7 @@ const SoundPlayer: React.FunctionComponent<{
 
         player.setMidi(midi);
 
-        await player.loadInstruments();
+        await player.loadInstruments({ volume });
         setLoading(false);
 
         midi.staffVisualiser(
@@ -179,7 +181,7 @@ const SoundPlayer: React.FunctionComponent<{
         );
       })();
     },
-    [player, staffVisualiserRef, setActiveMidis]
+    [player, staffVisualiserRef, setActiveMidis, volume]
   );
 
   const onTogglePlay = useCallback(() => {
@@ -241,6 +243,14 @@ const SoundPlayer: React.FunctionComponent<{
     [player]
   );
 
+  const handleVolumeChange = useCallback(
+    volume => {
+      player.setVolume(volume);
+      setVolume(volume);
+    },
+    [player]
+  );
+
   return (
     <PlayerContext.Provider value={player}>
       <ThemeContext.Provider value={theme}>
@@ -267,6 +277,8 @@ const SoundPlayer: React.FunctionComponent<{
             midiSettings={midiSettings}
             onMidiDeviceChange={setSelectedMidiDevice}
             onThemeChange={setTheme}
+            volume={volume}
+            onVolumeChange={handleVolumeChange}
             isLoading={loading}
           />
 

--- a/utils/MidiPlayer/MidiPlayer.ts
+++ b/utils/MidiPlayer/MidiPlayer.ts
@@ -59,11 +59,14 @@ export class MidiPlayer {
   private is2dOffscreenCanvasSupported =
     OFFSCREEN_2D_CANVAS_SUPPORT.DETERMINING;
 
-  static getTrackSampler = audio =>
+  static getTrackSampler = (audio, volume) =>
     new Promise(resolve => {
-      const sampler = new Tone.Sampler(audio, () => {
-        sampler.connect(Tone.Master);
-        resolve(sampler);
+      const sampler = new Tone.Sampler(audio, {
+        onload: () => {
+          sampler.connect(Tone.Master);
+          resolve(sampler);
+        },
+        volume
       });
     });
 
@@ -104,6 +107,7 @@ export class MidiPlayer {
   public loadInstruments = async (options?: {
     instrumentIds?: string[];
     drums?: boolean;
+    volume?: number;
   }) => {
     const { instrumentIds, drums } = {
       instrumentIds:
@@ -130,7 +134,10 @@ export class MidiPlayer {
       trackInstrumentIds.map(
         instrumentId =>
           this.trackSamplers[instrumentId] ||
-          MidiPlayer.getTrackSampler(data.tracks[instrumentId])
+          MidiPlayer.getTrackSampler(
+            data.tracks[instrumentId],
+            options?.volume || 0
+          )
       )
     );
 
@@ -322,7 +329,7 @@ export class MidiPlayer {
     this.drumSampler._volume.mute = !this.drumSampler._volume.mute;
   };
 
-  public toggleTracksVolume = () => {
+  public toggleTracksMute = () => {
     const { tracks } = this.midi;
 
     const mainTrackInstrumentIndex =
@@ -338,6 +345,12 @@ export class MidiPlayer {
           instrumentIndex
         ]._volume.mute;
       }
+    });
+  };
+
+  public setVolume = (volumeValue: number) => {
+    Object.values(this.trackSamplers).forEach(sampler => {
+      sampler.volume.value = volumeValue;
     });
   };
 

--- a/utils/MidiPlayer/MidiPlayer.ts
+++ b/utils/MidiPlayer/MidiPlayer.ts
@@ -329,7 +329,7 @@ export class MidiPlayer {
     this.drumSampler._volume.mute = !this.drumSampler._volume.mute;
   };
 
-  public toggleTracksMute = () => {
+  public toggleTracksVolume = () => {
     const { tracks } = this.midi;
 
     const mainTrackInstrumentIndex =


### PR DESCRIPTION
![Screen Shot 2020-12-27 at 1 47 17 AM](https://user-images.githubusercontent.com/5341184/103168174-dade0b80-47e5-11eb-85a5-c57918fe12f2.png)

Default: 0 dB (no change)
![Screen Shot 2020-12-27 at 1 50 59 AM](https://user-images.githubusercontent.com/5341184/103168197-fd702480-47e5-11eb-8c6e-6812d6dc79d8.png)

Max: +10 dB (about twice as loud as 0 dB)
![Screen Shot 2020-12-27 at 1 51 49 AM](https://user-images.githubusercontent.com/5341184/103168218-1ed11080-47e6-11eb-9857-ccf34f5ae68b.png)

Min: -10 dB (about half as loud as 0 dB)
![Screen Shot 2020-12-27 at 1 50 30 AM](https://user-images.githubusercontent.com/5341184/103168190-f2b58f80-47e5-11eb-87e1-f7b959572511.png)

Muted (volume slide is disabled and semi-transparent)
![Screen Shot 2020-12-27 at 1 50 40 AM](https://user-images.githubusercontent.com/5341184/103168191-f3e6bc80-47e5-11eb-9198-f288e1febdd1.png)
