### PR TITLE
Add height style to Dropdown (instrument-selector)

### DIFF
--- a/components/WriteModeControls/WriteModeControls.tsx
+++ b/components/WriteModeControls/WriteModeControls.tsx
@@ -55,7 +55,7 @@ const _WriteModeControls: React.FunctionComponent<WriteModeControlsProps> = ({
         )}
       >
         {close => (
-          <div className="py-2" style={{ width: 180 }}>
+          <div className="py-2" style={{ width: 180, maxHeight: 300 }}>
             <input
               onChange={onSearchChange}
               type="text"


### PR DESCRIPTION
Fix to #119 

Add `maxHeight: 300` style to div inside Dropdown instrument-selector

before: `<div className="py-2" style={{ width: 180 }}>`
after: `<div className="py-2" style={{ width: 180, maxHeight: 300 }}>`